### PR TITLE
fix: removed memory leak

### DIFF
--- a/samples/delphi/samples.dpr
+++ b/samples/delphi/samples.dpr
@@ -7,6 +7,7 @@ uses
 {$R *.res}
 
 begin
+  ReportMemoryLeaksOnShutdown := True;
   Application.Initialize;
   Application.MainFormOnTaskbar := True;
   Application.CreateForm(TFrmSamples, FrmSamples);

--- a/src/Xml.Reader.pas
+++ b/src/Xml.Reader.pas
@@ -36,6 +36,7 @@ type
     function Encoding: string;
   public
     constructor Create;
+    destructor Destroy; override;
     class function New: IXmlReader;
   end;
 
@@ -53,6 +54,14 @@ uses Xml.Reader.Attribute, Xml.Reader.Element, Xml.Reader.Node,
 constructor TXmlReader.Create;
 begin
   FNode := TXmlNode.New;
+end;
+
+destructor TXmlReader.Destroy;
+begin
+  Node.Attributes.Clear;
+  Node.Elements.Clear;
+  Node.Nodes.Clear;
+  inherited;
 end;
 
 function TXmlReader.Encoding: string;


### PR DESCRIPTION
Removed memory leak due to TList properties on IXmlNode needing to be cleaned up when destroying the class implementation